### PR TITLE
Add hidden input to preserve parent wiki page when creating a new page.

### DIFF
--- a/app/views/wiki/eligeplantilla.erb
+++ b/app/views/wiki/eligeplantilla.erb
@@ -6,6 +6,9 @@
 :id => 'wiki_form'}  do |f| %>
 <%= error_messages_for 'content' %>
 
+<%# Preserve wiki page parent: %>
+<input name="parent" type="hidden" value="<%=params[:parent]%>">
+
 <div class="box tabular">
 <p><label for="issue_plantilla"><%= l(:label_choose_template) %></label>
 <select id="issue_plantilla" name="issue_plantilla">


### PR DESCRIPTION
There seems to be a bug in this plugin; when a user creates a new wiki page, the parent page is lost in when the page is displayed. The template selection page is passed the parent as a parameter, but this is not taken into account. 

My solution was to add a hidden input that passes the parameter on - maybe there's a better way.
