### PR TITLE
Fix template crash

### DIFF
--- a/app/views/wiki/eligeplantilla.erb
+++ b/app/views/wiki/eligeplantilla.erb
@@ -2,7 +2,7 @@
 
 <h2><%=h @page.pretty_title %></h2>
 
-<%= labelled_form_for @template, :as => :template,:url => {:action => 'edit', :action => 'edit', :project_id => @project_id, :id => @page.title}, :html => {:method => :get, :multipart => false, 
+<%= labelled_form_for @templates, :as => :template,:url => {:action => 'edit', :action => 'edit', :project_id => @project_id, :id => @page.title}, :html => {:method => :get, :multipart => false, 
 :id => 'wiki_form'}  do |f| %>
 <%= error_messages_for 'content' %>
 


### PR DESCRIPTION
The template array appears to be incorrectly referenced as 'template', when it should be 'templates'.  Seems to work with redmine 3.2.4  (so far...)